### PR TITLE
Fix manifest syntax error

### DIFF
--- a/modules/web-app-manifest/tests/playwright/WebAppManifest.spec.js
+++ b/modules/web-app-manifest/tests/playwright/WebAppManifest.spec.js
@@ -31,7 +31,9 @@ test('web app manifest meta link is present in the html', async ({ page }) => {
     },
     async ({ url }) => {
       const response = await page.goto(url)
-      expect(await response.text()).toContain('<link rel="manifest" href="/manifest.webmanifest">')
+      expect(await response.text()).toContain(
+        '<link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest">',
+      )
     },
   )
 })

--- a/modules/web-app-manifest/vue/plugins/Manifest.server.ts
+++ b/modules/web-app-manifest/vue/plugins/Manifest.server.ts
@@ -2,7 +2,7 @@ import type { App } from 'vue'
 import webAppManifest from '~/.sfx/webAppManifest'
 
 export const after = async (app: App, ctx?: any) => {
-  let content = `<link rel="manifest" href="/manifest.webmanifest">`
+  let content = `<link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest">`
 
   if (webAppManifest.theme_color) {
     content += `<meta name="theme-color" content="${webAppManifest.theme_color}" />`


### PR DESCRIPTION
Fix manifest syntax error in chrome - only on live envs. like stage or prod

<img width="1799" alt="image" src="https://user-images.githubusercontent.com/39699015/221288515-57b5a45a-92cf-483f-b620-1198aa1b9b87.png">
