### PR TITLE
Move Vite cache to the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ sw.*
 !.yarn/sdks
 !.yarn/versions
 
+# Vite
+.vite
+
 # Vitepress
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/modules/core/src/Core.js
+++ b/modules/core/src/Core.js
@@ -33,7 +33,7 @@ export default class Core {
 
     this.viteConfig = vite.mergeConfig(
       vite.defineConfig({
-        cacheDir: path.resolve(this.buildDir, '.vite'),
+        cacheDir: path.resolve(this.rootDir, '.vite'),
         envDir: this.rootDir,
         envPrefix: 'SFX_',
         publicDir: false,


### PR DESCRIPTION
Moving Vite cache to the root directory causes Vite cache to remain on the disk between SFX bootstraps, thus improving startup time during development.