### PR TITLE
Add env var for Lets Encrypt certificates

### DIFF
--- a/mxcloud/docker-compose.mxcloud.yml
+++ b/mxcloud/docker-compose.mxcloud.yml
@@ -7,6 +7,7 @@ services:
       - VIRTUAL_PORT=3000
       - VIRTUAL_PROTO=https
       - VIRTUAL_HOST=${PROJECT_BASE_URL}
+      - LETSENCRYPT_HOST=${PROJECT_BASE_URL}
     restart: ${RESTART_POLICY:-unless-stopped}
     networks:
       - mxcloud_http


### PR DESCRIPTION
## What does this PR do and why?

Adding env var for deploy to mxcloud for getting LE certs for demos

## What is added?

**Added**
- env var LETSENCRYPT_HOST in `mxcloud/docker-compose.mxcloud.yml` file