### PR TITLE
Load .env file during MxCloud build

### DIFF
--- a/mxcloud/docker-compose.mxcloud.yml
+++ b/mxcloud/docker-compose.mxcloud.yml
@@ -9,6 +9,8 @@ services:
       - VIRTUAL_HOST=${PROJECT_BASE_URL}
       - LETSENCRYPT_HOST=${PROJECT_BASE_URL}
     restart: ${RESTART_POLICY:-unless-stopped}
+    env_file:
+      - .env
     networks:
       - mxcloud_http
 


### PR DESCRIPTION
## What does this PR do and why?

Fix loading env variables from whole .env file into app docker container 

## What is added/fixed/removed?

**Fixed**
- load all env vars from .env file generated by mxcloud
