### PR TITLE
Move brand attribute name to config

### DIFF
--- a/modules/brands-magento/graphql/queries/BrandDetail.ts
+++ b/modules/brands-magento/graphql/queries/BrandDetail.ts
@@ -2,7 +2,7 @@ import field from '#ioc/graphql/field'
 import Brand from '#ioc/graphql/fragments/Brand'
 import ProductInListing from '#ioc/graphql/fragments/ProductInListing'
 import query from '#ioc/graphql/query'
-import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME.ts'
+import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME'
 
 export default () =>
   query()

--- a/modules/brands-magento/graphql/queries/BrandDetail.ts
+++ b/modules/brands-magento/graphql/queries/BrandDetail.ts
@@ -2,7 +2,7 @@ import field from '#ioc/graphql/field'
 import Brand from '#ioc/graphql/fragments/Brand'
 import ProductInListing from '#ioc/graphql/fragments/ProductInListing'
 import query from '#ioc/graphql/query'
-import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME'
+import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME.ts'
 
 export default () =>
   query()

--- a/modules/brands-magento/graphql/queries/BrandDetail.ts
+++ b/modules/brands-magento/graphql/queries/BrandDetail.ts
@@ -2,6 +2,7 @@ import field from '#ioc/graphql/field'
 import Brand from '#ioc/graphql/fragments/Brand'
 import ProductInListing from '#ioc/graphql/fragments/ProductInListing'
 import query from '#ioc/graphql/query'
+import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME'
 
 export default () =>
   query()
@@ -35,7 +36,7 @@ export default () =>
           }),
         }),
       aggregations: field('products')
-        .args({ filter: { manufacturer: { eq: '$manufacturer' } } })
+        .args({ filter: { [BRAND_ATTRIBUTE_NAME]: { eq: '$manufacturer' } } })
         .fields({
           aggregations: field({
             attribute_code: field(),

--- a/modules/brands-magento/repositories/useGetBrandDetailByIdRepository.ts
+++ b/modules/brands-magento/repositories/useGetBrandDetailByIdRepository.ts
@@ -7,6 +7,7 @@ import transformFilterQuery from '#ioc/utils/magento/transformFilterQuery'
 import ToProduct from '#ioc/mappers/ToProduct'
 import ToAggregation from '#ioc/mappers/ToAggregation'
 import CATALOG_FILTER_ATTRIBUTES_HIDDEN from '#ioc/config/magento/CATALOG_FILTER_ATTRIBUTES_HIDDEN'
+import BRAND_ATTRIBUTE_NAME from '#ioc/config/BRAND_ATTRIBUTE_NAME'
 
 interface BrandOptions {
   page?: number
@@ -34,7 +35,7 @@ export default () => {
         currentPage: page || 1,
         sort: transformSortQuery(sort),
         filter: {
-          manufacturer: { eq: id },
+          [BRAND_ATTRIBUTE_NAME]: { eq: id },
           ...transformFilterQuery(filter),
         },
       }),

--- a/modules/create-storefront-x/template/magento/modules/demo-magento/config/BRAND_ATTRIBUTE_NAME.ts
+++ b/modules/create-storefront-x/template/magento/modules/demo-magento/config/BRAND_ATTRIBUTE_NAME.ts
@@ -1,0 +1,1 @@
+export default 'sap_brand'

--- a/modules/create-storefront-x/template/magento/modules/demo-magento/config/BRAND_ATTRIBUTE_NAME.ts
+++ b/modules/create-storefront-x/template/magento/modules/demo-magento/config/BRAND_ATTRIBUTE_NAME.ts
@@ -1,1 +1,1 @@
-export default 'sap_brand'
+export default 'manufacturer'

--- a/modules/create-storefront-x/template/px/modules/demo-px/config/BRAND_ATTRIBUTE_NAME.ts
+++ b/modules/create-storefront-x/template/px/modules/demo-px/config/BRAND_ATTRIBUTE_NAME.ts
@@ -1,0 +1,1 @@
+export default 'sap_brand'

--- a/modules/create-storefront-x/template/px/modules/demo-px/config/BRAND_ATTRIBUTE_NAME.ts
+++ b/modules/create-storefront-x/template/px/modules/demo-px/config/BRAND_ATTRIBUTE_NAME.ts
@@ -1,1 +1,1 @@
-export default 'sap_brand'
+export default 'manufacturer'


### PR DESCRIPTION
In Magento, we can use as a brand attribute a different attribute than the default "manufacturer"
