### PR TITLE
Implement image resizer fallback url

### DIFF
--- a/modules/base-commerce/components/SfxImage.vue
+++ b/modules/base-commerce/components/SfxImage.vue
@@ -78,6 +78,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    fallbackImageUrl: {
+      type: String,
+      default: undefined,
+    },
   },
 
   computed: {
@@ -110,6 +114,7 @@ export default defineComponent({
         fit: this.fit,
         position: this.position,
         format,
+        fallback: this.fallbackImageUrl,
         ...rest,
       })
     },

--- a/modules/base-commerce/config/IMAGE_RESIZER_FALLBACK_IMAGE_URL.ts
+++ b/modules/base-commerce/config/IMAGE_RESIZER_FALLBACK_IMAGE_URL.ts
@@ -1,0 +1,1 @@
+export default null


### PR DESCRIPTION
Image resizer and SfxImage now support fallback image. It can either be configured globally via `config/IMAGE_RESIZER_FALLBACK_IMAGE_URL.ts` (e.g.: `export default '/fallback-image.jpg'`) or locally via SfxImage `fallback-image-url` prop (e.g.: `<SfxImage fallback-image-url="/fallback-image.jpg"`).

Fallback image URL can either start with slash (will use local image inside public concept) or with http in which case the image will be downloaded over the internet.